### PR TITLE
Add installation directory to setup.py so python setup.py works

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,25 +5,26 @@
 from setuptools import setup
 import os
 
-long_description='Please read the documentation on Github and official Vialux documentation.'
+long_description = 'Please read the documentation on Github and official Vialux documentation.'
 if os.path.exists('README.txt'):
     long_description = open('README.txt').read()
 
 setup(
-    name = "ALP4lib",
-    version = "0.0.4",
-    author = "Sebastien Popoff",
-    author_email = "sebastien.popoff@espci.fr",
-    description = ("A module to control Vialux DMDs based on ALP4.X API."
-                   "It uses the .ddl files provided by Vialux."),
-    license = "MIT",
-    keywords = "DMD Vialux",
-    url = "https://github.com/wavefronthsaping/ALP4lib",
-    py_modules = ['ALP4'],
+    name="ALP4lib",
+    version="0.0.4",
+    author="Sebastien Popoff",
+    author_email="sebastien.popoff@espci.fr",
+    description=("A module to control Vialux DMDs based on ALP4.X API."
+                 "It uses the .ddl files provided by Vialux."),
+    license="MIT",
+    keywords="DMD Vialux",
+    url="https://github.com/wavefronthsaping/ALP4lib",
+    package_dir={'': 'src'},
+    py_modules=['ALP4'],
     long_description=long_description,
     classifiers=[
-		"Programming Language :: Python :: 2",
-		"Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Education",
         "Topic :: Scientific/Engineering",

--- a/src/ALP4.py
+++ b/src/ALP4.py
@@ -55,8 +55,10 @@ ALP_DMDTYPE_XGA_055A	 =  5 #	1024*768 mirror pixels (0.55" Type A, D4x00)
 ALP_DMDTYPE_XGA_055X	 =  6	#	1024*768 mirror pixels (0.55" Type X, D4x00) 
 ALP_DMDTYPE_WUXGA_096A =	   7	#	1920*1200 mirror pixels (0.96" Type A, D4100) 
 ALP_DMDTYPE_WQXGA_400MHZ_090A = 8 #	2560*1600 mirror pixels (0.90" Type A, DLPC910) at standard clock rate (400 MHz) 
-ALP_DMDTYPE_WQXGA_480MHZ_090A = 9 #	WQXGA at extended clock rate (480 MHz); WARNING: This mode requires temperature control of DMD 
-ALP_DMDTYPE_DISCONNECT = 255 #	behaves like 1080p (D4100) 
+ALP_DMDTYPE_WQXGA_480MHZ_090A = 9 #	WQXGA at extended clock rate (480 MHz); WARNING: This mode requires temperature control of DMD
+ALP_DMDTYPE_WXGA_S450 = 12 # # 1280x800 (DLP650LNIR WXGA S450)
+ALP_DMDTYPE_DISCONNECT = 255 #	behaves like 1080p (D4100)
+
 
 ALP_DEV_DISPLAY_HEIGHT = 2057	# number of mirror rows on the DMD 
 ALP_DEV_DISPLAY_WIDTH = 2058 # number of mirror columns on the DMD 
@@ -399,7 +401,10 @@ class ALP4():
             self.nSizeX = 1920; self.nSizeY = 1200
         elif (self.DMDType.value == ALP_DMDTYPE_WQXGA_400MHZ_090A or self.DMDType.value == ALP_DMDTYPE_WQXGA_480MHZ_090A):
             self.nSizeX = 2560; self.nSizeY = 1600
+        elif (self.DMDType.value == ALP_DMDTYPE_WXGA_S450):
+            self.nSizeX = 1280; self.nSizeY = 800
         else:
+            print("Unknown DMDtype with value ", self.DMDtype.value)
             self._raiseError("DMD Type not supported or unknown.")
 
         print('DMD found, resolution = ' + str(self.nSizeX) + ' x ' + str(self.nSizeY) + '.')

--- a/src/ALP4.py
+++ b/src/ALP4.py
@@ -515,13 +515,14 @@ class ALP4():
                                   ct.c_long(LineOffset), 
                                   ct.c_long(LineLoad))
         
-            
-        if dataFormat == 'Python':  
-            pImageData = (ct.c_ubyte*imgData.size)()
-            for ind,x in enumerate(imgData):
-                pImageData[ind] = x
+        if dataFormat not in ['Python', 'C']:
+            raise ValueError('dataFormat must be one of "Python" or "C"')
+
+        if dataFormat == 'Python':
+            pImageData = imgData.astype(np.uint8).ctypes.data_as(ct.c_void_p)
         elif dataFormat == 'C':
-            pImageData = ct.cast(imgData,ct.c_void_p)  
+            pImageData = ct.cast(imgData,ct.c_void_p)
+
 
         self._checkError(self._ALPLib.AlpSeqPutEx(self.ALP_ID,  SequenceId, LinePutParam, pImageData),'Cannot send image sequence to device.')
 
@@ -570,15 +571,15 @@ class ALP4():
         
         See ALPLib.AlpSeqPut in the ALP API description for more information.
         '''
-        
+
+
         if not SequenceId:
             SequenceId = self._lastDDRseq 
-        
-            
-        if dataFormat == 'Python':  
-            pImageData = (ct.c_ubyte*imgData.size)()
-            for ind,x in enumerate(imgData):
-                pImageData[ind] = x
+        if dataFormat not in ['Python', 'C']:
+            raise ValueError('dataFormat must be one of "Python" or "C"')
+
+        if dataFormat == 'Python':
+            pImageData = imgData.astype(np.uint8).ctypes.data_as(ct.c_void_p)
         elif dataFormat == 'C':
             pImageData = ct.cast(imgData,ct.c_void_p)  
             


### PR DESCRIPTION
When I was trying to install the package it failed for some nonobvious reason. I found out that adding the package_dir argument to setup.py fixes it. As far as I can see the installation now runs fine on my PC.