### PR TITLE
remove unnecessary requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,6 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     install_requires=[
-        'numpy',
-        'matplotlib',
-        'scipy',
-        'numba',
-        'joblib'
+        'numpy'
     ],
 )


### PR DESCRIPTION
Hello!
Thanks for your wonderful work.
I find that some extra packages (e.g. numba) were installed when I install ALP4lib via pip. I think these unused packages can be removed from the setup.py script.